### PR TITLE
Fix for "ValueError: invalid literal for int() with base 10: 'xx.x'"

### DIFF
--- a/ui/xdot.py
+++ b/ui/xdot.py
@@ -493,7 +493,7 @@ class XDotAttrParser:
         return res
 
     def read_number(self):
-        return int(self.read_code())
+        return int(float(self.read_code()))
 
     def read_float(self):
         return float(self.read_code())


### PR DESCRIPTION
After loading file to bokken I've got:
Traceback (most recent call last):
  File "/usr/share/pyshared/bokken/ui/main.py", line 303, in merge_dasm_rightextview
    self.tviews.update_graph(self, link_name)
  File "/usr/share/pyshared/bokken/ui/textviews.py", line 386, in update_graph
    self.right_notebook.xdot_box.set_dot(self.uicore.get_callgraph(addr))
  File "/usr/share/pyshared/bokken/ui/graph.py", line 50, in set_dot
    self.dot_widget.set_dotcode(dotcode)
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 1475, in set_dotcode
    self.set_xdotcode(xdotcode)
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 1491, in set_xdotcode
    self.graph = parser.parse()
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 1169, in parse
    DotParser.parse(self)
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 979, in parse
    self.parse_graph()
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 988, in parse_graph
    self.parse_stmt()
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 1034, in parse_stmt
    self.handle_node(id, attrs)
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 1144, in handle_node
    shapes.extend(parser.parse())
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 602, in parse
    x, y = s.read_point()
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 503, in read_point
    y = self.read_number()
  File "/usr/share/pyshared/bokken/ui/xdot.py", line 496, in read_number
    return int(self.read_code())
ValueError: invalid literal for int() with base 10: '132.6'
To fix it, I translate string to float and after that to int type.